### PR TITLE
Set default memory at 250m

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -34,9 +34,9 @@ services:
       - ./.compose/neo4j/plugins:/plugins
     environment:
       # Raise memory limits:
-      - NEO4J_dbms_memory_pagecache_size=1G
-      - NEO4J_dbms.memory.heap.initial_size=1G
-      - NEO4J_dbms_memory_heap_max__size=1G
+      - NEO4J_dbms_memory_pagecache_size=250m
+      - NEO4J_dbms.memory.heap.initial_size=250m
+      - NEO4J_dbms_memory_heap_max__size=250m
       # Auth:
       - NEO4J_AUTH=none
       # Add APOC and GDS:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,9 +28,9 @@ services:
       - neo4j_plugins:/plugins
     environment:
       # Raise memory limits:
-      - NEO4J_dbms_memory_pagecache_size=1G
-      - NEO4J_dbms.memory.heap.initial_size=1G
-      - NEO4J_dbms_memory_heap_max__size=1G
+      - NEO4J_dbms_memory_pagecache_size=250m
+      - NEO4J_dbms.memory.heap.initial_size=250m
+      - NEO4J_dbms_memory_heap_max__size=250m
       # Auth:
       - NEO4J_AUTH=none
       # Add APOC and GDS:


### PR DESCRIPTION
Default docker desktop memory is 2G which causes a failure w/ 1G limits